### PR TITLE
Implement transformation rules for dependent set comprehension

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,14 @@ bimap = "0.6.1"
 # timely = { version = "0.11.1", features = ["bincode"] } 
 # timely = { path = "../timely-dataflow/timely/", features = ["bincode"] }
 # timely = { path = "../timely-dataflow/timely/" }
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }
 # timely = { git = "https://github.com/TimelyDataflow/timely-dataflow" }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }
 timely_sort = "0.1.6"
 
 # Internally differential-dataflow use timely as a dependency and they have to be at the same version.
 # differential-dataflow = "0.11.0"
-differential-dataflow = { path = "../differential-dataflow" }
-# differential-dataflow = { git = "https://github.com/qishen/differential-dataflow.git", branch = "add-serde-fields" }
+# differential-dataflow = { path = "../differential-dataflow" }
+differential-dataflow = { git = "https://github.com/qishen/differential-dataflow" }
 
 # Import a local differential-datalog library.
 # types = { path = "../differential-datalog/rust/template/types" }

--- a/README.md
+++ b/README.md
@@ -1,12 +1,28 @@
 # differential-formula
 Incremental Formal Modeling Using Logic Programming and Analysis
 
-## Installation
-1. Install [Rust](https://www.rust-lang.org/tools/install) toolchain and [Differential-Datalog](https://github.com/vmware/differential-datalog) following the tutorials in the links. Use command `ddlog --version` to check if DDLog is successfully installed in the local environment. Maintain a copy of **Differential-Datalog** source code so we can call its standard library later.
+## Install Dependencies
+1. Install [Rust](https://www.rust-lang.org/tools/install) toolchain, [.NET SDK and Runtime](https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu) and [Differential-Datalog](https://github.com/vmware/differential-datalog) following the tutorials in the links. Use command `ddlog --version` to check if DDLog is successfully installed in the local environment. Maintain a copy of **Differential-Datalog** source code so we can call its standard library later.
 
-2. Go to `ddlog_examples/formula2ddlog` and run `ddlog -i formula2ddlog.dl`. If DDLog cannot find the dependencies try `ddlog -i formula2ddlog.dl -L /path/to/differential-datalog/lib/` with additional argument to specify the path of standard library. After that DDLog generates a specific Rust runtime in `ddlog_examples/formula2ddlog/formula2ddlog_ddlog` for `formula2ddlog.dl` that provides DDLog Rust APIs for incremental computation based on **differential-datalog** 
+## Building
+1. Generate a Rust Runtime for `formula2ddlog` transformation tool 
+	- Go to directory `ddlog_examples/formula2ddlog` and run `ddlog -i formula2ddlog.dl`. If DDLog cannot find the dependencies try `ddlog -i formula2ddlog.dl -L /path/to/differential-datalog/lib/` with additional argument to specify the path of standard library. 
+	- The Rust runtime for `formula2ddlog` is generated in directory `ddlog_examples/formula2ddlog/formula2ddlog_ddlog` based on the DDLog program `formula2ddlog.dl` that formally specifies the transformation rules from FORMULA to DDLog.
+	- Build the Rust runtime directly if you want to use the raw transformation tool in command line by running `cargo build --release` inside `formula2ddlog_ddlog`. The command line only accepts data written in DDLog format.
+
+2. Build the `formula2ddlog_lib` with command `cargo run --release` which will use the Rust runtime built from `formula2ddlog.dl` as library and generate an executable for transformation tool. This tool can translate any FORMULA file such as `formula2ddlog/examples/graph/graph.4ml` in our example into an equivalent DDLog program in `graph.dl` in the same folder. 
+
+
+3. Copy the DDLog program into `ddlog_examples/formula2ddlog/example/graph/graph.dl` and run `ddlog -i graph.dl` to generate a Rust runtime for the graph domain that can execute constraint checking and model transformation incrementally. The Rust runtime for graph domain is generated in `graph_ddlog` and a separate `graph_lib` uses the Rust runtime in `graph_ddlog` as library to build an executable that does graph domain related computation incrementally.
 
 ## Testing
-1. Go to `ddlog_examples/formula2ddlog/formula2ddlog_lib` and run `cargo run` to transform the model of a FORMULA program `formula2ddlog/examples/graph/graph.4ml` into the model of an equivalent DDLog program. The model of DDLog program is then translated into a real DDLog program and printed out in the command line.
+Run `ddlog_examples/formula2ddlog/run.sh` to benchmark constraint checking on random graph in both FORMULA and DDLog.
 
-2. Copy the DDLog program into `ddlog_examples/formula2ddlog/example/graph.dl` and run `ddlog -i graph.dl` to generate a Rust runtime for the graph domain that can execute constraint checking and model transformation incrementally.
+```
+Usage:
+run.sh <NODE=2000> <EDGE=100> <TARGET=ddlog>
+```
+
+if the target is set to `ddlog` or `formula`, <NODE> and <EDGE> are the attributes of the auto-generated random graph. The constraint checking will only be executed once on the random graph with the exact size we specify in the arguments or the default value.
+
+if the target is for benchmark as `ddlog_bench` or `formula_bench`, <NODE> is the number of nodes for the auto-generated random graph but <EDGE> is number for both initial edges and the range interval. The constraint checking will be executed multiple times for the benchmarking.

--- a/ddlog_examples/formula2ddlog/examples/graph/graph.4ml
+++ b/ddlog_examples/formula2ddlog/examples/graph/graph.4ml
@@ -16,7 +16,7 @@ domain Graph {
     Path(a, c) :- Path(a, b), Path(b, c). 
     //Nocycle(u) :- Edge(u, v), no Path(u, u).
     Nocycle(u) :- u is Node(_), no Path(u, u).
-    //HasNoCycle :- no Path(u, u).
+    HasNoCycle :- no Path(u, u).
     //OutdegreeByNode(src, amt) :- src is Node(_), amt = count({ e | e is Edge(src, dst) }). 
 	// src :- e is Edge(src, dst).
     //Outdegree(amt) :- amt = count({ "hello", src, Edge(dst, src), Edge(src, dst) | e is Edge(src, dst) }). 

--- a/ddlog_examples/formula2ddlog/examples/graph/graph.4ml
+++ b/ddlog_examples/formula2ddlog/examples/graph/graph.4ml
@@ -12,12 +12,12 @@ domain Graph {
     Outdegree ::= new(degrees: Integer).
 
     //Edge(a, c) :- Edge(a, b), Edge(b, c).
-    Path(a, b) :- Edge(a, b).
-    Path(a, c) :- Path(a, b), Path(b, c). 
+    // Path(a, b) :- Edge(a, b).
+    // Path(a, c) :- Path(a, b), Path(b, c). 
     //Nocycle(u) :- Edge(u, v), no Path(u, u).
-    Nocycle(u) :- u is Node(_), no Path(u, u).
-    HasNoCycle :- no Path(u, u).
-    //OutdegreeByNode(src, amt) :- src is Node(_), amt = count({ e | e is Edge(src, dst) }). 
+    // Nocycle(u) :- u is Node(_), no Path(u, u).
+    // HasNoCycle :- no Path(u, u).
+    OutdegreeByNode(src, amt) :- src is Node(_), amt = count({ e, src, Edge(src, src) | e is Edge(src, dst) }). 
 	// src :- e is Edge(src, dst).
     //Outdegree(amt) :- amt = count({ "hello", src, Edge(dst, src), Edge(src, dst) | e is Edge(src, dst) }). 
     //Outdegree(amt) :- amt * 2 > 10, amt = count({ src, Edge(dst, src), Edge(src, dst) | e is Edge(src, dst) }). 

--- a/ddlog_examples/formula2ddlog/examples/graph/graph.dl
+++ b/ddlog_examples/formula2ddlog/examples/graph/graph.dl
@@ -1,3 +1,5 @@
+typedef BoolConstantHasNoCycle = BoolConstantHasNoCycle{}
+typedef BoolConstantR3N0 = BoolConstantR3N0{}
 typedef Edge = Edge{src: Node, dst: Node}
 typedef Graph_AUTOTYPE0 = Graph_AUTOTYPE0_usize{usize_field: usize} | Graph_AUTOTYPE0_string{string_field: string}
 typedef Graph_AUTOTYPE1 = Graph_AUTOTYPE1_Node{node_field: Node} | Graph_AUTOTYPE1_usize{usize_field: usize}
@@ -10,6 +12,8 @@ typedef Outdegree = Outdegree{degrees: usize}
 typedef OutdegreeByNode = OutdegreeByNode{node: Node, degrees: usize}
 typedef Path = Path{src: Node, dst: Node}
 typedef TwoEdge = TwoEdge{first: Edge, second: Edge}
+output relation BoolConstantHasNoCycle[BoolConstantHasNoCycle]
+output relation BoolConstantR3N0[BoolConstantR3N0]
 output relation Edge[Edge]
 output relation Graph_AUTOTYPE0[Graph_AUTOTYPE0]
 output relation Graph_AUTOTYPE1[Graph_AUTOTYPE1]
@@ -34,6 +38,8 @@ input relation OutdegreeByNodeInput[OutdegreeByNode]
 input relation OutdegreeInput[Outdegree]
 input relation PathInput[Path]
 input relation TwoEdgeInput[TwoEdge]
+BoolConstantHasNoCycle[BoolConstantHasNoCycle{}] :- BoolConstantR3N0[p].
+BoolConstantR3N0[BoolConstantR3N0{}] :- p in Path[Path{u, u1}], u == u1, var g = (p).group_by(()), var num = g.group_count(), num == 0.
 Edge[p] :- EdgeInput[p].
 Graph_AUTOTYPE0[p] :- Graph_AUTOTYPE0Input[p].
 Graph_AUTOTYPE1[p] :- Graph_AUTOTYPE1Input[p].

--- a/ddlog_examples/formula2ddlog/examples/graph/graph.dl
+++ b/ddlog_examples/formula2ddlog/examples/graph/graph.dl
@@ -1,5 +1,3 @@
-typedef BoolConstantHasNoCycle = BoolConstantHasNoCycle{}
-typedef BoolConstantR3N0 = BoolConstantR3N0{}
 typedef Edge = Edge{src: Node, dst: Node}
 typedef Graph_AUTOTYPE0 = Graph_AUTOTYPE0_usize{usize_field: usize} | Graph_AUTOTYPE0_string{string_field: string}
 typedef Graph_AUTOTYPE1 = Graph_AUTOTYPE1_Node{node_field: Node} | Graph_AUTOTYPE1_usize{usize_field: usize}
@@ -11,9 +9,11 @@ typedef Node = Node{name: Graph_AUTOTYPE0}
 typedef Outdegree = Outdegree{degrees: usize}
 typedef OutdegreeByNode = OutdegreeByNode{node: Node, degrees: usize}
 typedef Path = Path{src: Node, dst: Node}
+typedef PostAggrContainerR0SC0Dot1 = PostAggrContainerR0SC0Dot1{src: Node, sc_result: SCResultR0SC0Dot1}
+typedef PreAggrContainerR0SC0Dot1 = PreAggrContainerR0SC0Dot1{src: Node, sc_union: SCHeadUnionR0SC0Dot1}
+typedef SCHeadUnionR0SC0Dot1 = SCHeadUnionR0SC0Dot1_Edge{edge_field: Edge} | SCHeadUnionR0SC0Dot1_Node{node_field: Node}
+typedef SCResultR0SC0Dot1 = SCResultR0SC0Dot1_usize{usize_field: usize} | SCResultR0SC0Dot1_float{float_field: float}
 typedef TwoEdge = TwoEdge{first: Edge, second: Edge}
-output relation BoolConstantHasNoCycle[BoolConstantHasNoCycle]
-output relation BoolConstantR3N0[BoolConstantR3N0]
 output relation Edge[Edge]
 output relation Graph_AUTOTYPE0[Graph_AUTOTYPE0]
 output relation Graph_AUTOTYPE1[Graph_AUTOTYPE1]
@@ -25,6 +25,9 @@ output relation Node[Node]
 output relation Outdegree[Outdegree]
 output relation OutdegreeByNode[OutdegreeByNode]
 output relation Path[Path]
+output relation PostAggrContainerR0SC0Dot1[PostAggrContainerR0SC0Dot1]
+output relation PreAggrContainerR0SC0Dot1[PreAggrContainerR0SC0Dot1]
+output relation SCHeadUnionR0SC0Dot1[SCHeadUnionR0SC0Dot1]
 output relation TwoEdge[TwoEdge]
 input relation EdgeInput[Edge]
 input relation Graph_AUTOTYPE0Input[Graph_AUTOTYPE0]
@@ -38,8 +41,6 @@ input relation OutdegreeByNodeInput[OutdegreeByNode]
 input relation OutdegreeInput[Outdegree]
 input relation PathInput[Path]
 input relation TwoEdgeInput[TwoEdge]
-BoolConstantHasNoCycle[BoolConstantHasNoCycle{}] :- BoolConstantR3N0[p].
-BoolConstantR3N0[BoolConstantR3N0{}] :- p in Path[Path{u, u1}], u == u1, var g = (p).group_by(()), var num = g.group_count(), num == 0.
 Edge[p] :- EdgeInput[p].
 Graph_AUTOTYPE0[p] :- Graph_AUTOTYPE0Input[p].
 Graph_AUTOTYPE1[p] :- Graph_AUTOTYPE1Input[p].
@@ -47,11 +48,11 @@ Graph_AUTOTYPE2[p] :- Graph_AUTOTYPE2Input[p].
 Line[p] :- LineInput[p].
 MagicEdge[p] :- MagicEdgeInput[p].
 Nocycle[p] :- NocycleInput[p].
-Nocycle[Nocycle{u}] :- u in Node[Node{_}], not Path[Path{u, u}].
 Node[p] :- NodeInput[p].
 Outdegree[p] :- OutdegreeInput[p].
 OutdegreeByNode[p] :- OutdegreeByNodeInput[p].
+OutdegreeByNode[OutdegreeByNode{src, amt}] :- src in Node[Node{_}], PostAggrContainerR0SC0Dot1[PostAggrContainerR0SC0Dot1{src, amt}].
 Path[p] :- PathInput[p].
-Path[Path{a, b}] :- Edge[Edge{a, b}].
-Path[Path{a, c}] :- Path[Path{a, b}], Path[Path{b, c}].
+PostAggrContainerR0SC0Dot1[PostAggrContainerR0SC0Dot1{src, result}] :- PreAggrContainerR0SC0Dot1[PreAggrContainerR0SC0Dot1{src, u}], var g = (u).group_by((src)), var result = g.group_count().
+PreAggrContainerR0SC0Dot1[PreAggrContainerR0SC0Dot1{src, SCHeadUnionR0SC0Dot1_Edge{e}}], PreAggrContainerR0SC0Dot1[PreAggrContainerR0SC0Dot1{src, SCHeadUnionR0SC0Dot1_Edge{Edge{src, src}}}], PreAggrContainerR0SC0Dot1[PreAggrContainerR0SC0Dot1{src, SCHeadUnionR0SC0Dot1_Node{src}}] :- PostAggrContainerR0SC0Dot1[PostAggrContainerR0SC0Dot1{src, amt}], e in Edge[Edge{src, dst}], src in Node[Node{_}].
 TwoEdge[p] :- TwoEdgeInput[p].

--- a/ddlog_examples/formula2ddlog/examples/graph/graph_lib/src/lib.rs
+++ b/ddlog_examples/formula2ddlog/examples/graph/graph_lib/src/lib.rs
@@ -10,7 +10,7 @@ use differential_datalog::{DDlog, DDlogDynamic};
 use differential_datalog::program::config::{Config, ProfilingConfig};
 use differential_datalog::api::HDDlog;
 use differential_datalog::DeltaMap; // A trait representing the changes resulting from a given update.
-use differential_datalog::ddval::DDValue; // A generic DLog value type
+use differential_datalog::ddval::{DDVal, DDValConvert, DDValMethods, DDValue}; // A generic DLog value type
 // use differential_datalog::ddval::DDValConvert; //Another helper trair
 use differential_datalog::program::RelId; // Numeric relations id
 use differential_datalog::program::Update; // A type representing updates to the database

--- a/ddlog_examples/formula2ddlog/examples/graph/graph_lib/src/lib.rs
+++ b/ddlog_examples/formula2ddlog/examples/graph/graph_lib/src/lib.rs
@@ -11,7 +11,7 @@ use differential_datalog::program::config::{Config, ProfilingConfig};
 use differential_datalog::api::HDDlog;
 use differential_datalog::DeltaMap; // A trait representing the changes resulting from a given update.
 use differential_datalog::ddval::DDValue; // A generic DLog value type
-use differential_datalog::ddval::DDValConvert; //Another helper trair
+// use differential_datalog::ddval::DDValConvert; //Another helper trair
 use differential_datalog::program::RelId; // Numeric relations id
 use differential_datalog::program::Update; // A type representing updates to the database
 

--- a/ddlog_examples/formula2ddlog/formula2ddlog.dl
+++ b/ddlog_examples/formula2ddlog/formula2ddlog.dl
@@ -297,7 +297,6 @@ DDRelation[setcompre_result_ddrelation] :-
 	// The name of new union type should include the rule id and the setcompre id
 	var sc_result_name = "SCResult" ++ "R" ++ rule_id ++ "SC" ++ sc_id, 
 	// TODO: Think about the type of aggregation results other than int and float.
-	// FIXME: the field name cannot be float or usize because they are reserved
 	var setcompre_result_type = union_of_ddtypes(sc_result_name, [Int, Float]),
 	var setcompre_result_ddrelation = DDRelation { false, sc_result_name, setcompre_result_type }.
 
@@ -380,7 +379,10 @@ DDRhsInRule[(dd_head_union_atom_rhs_with_def, rule)] :-
 // 1. Create `PreAggrContainer ::= (vco1: T1, vco2: T2,..., vcon: Tn, inner: SCHeadUnion)` where `vcox` is the 
 // variable in the outer scope and `Tn` is the type of that variable. 
 DDTypeSpec[pre_aggr_container_ddtype], 
-DDRelation[pre_aggr_container_ddrelation] :-
+DDRelation[pre_aggr_container_ddrelation] 
+// DDTypeSpec[], 
+// DDRelation[] 
+:-
 	DependentSetcompre[(setcompre, rule)], 
 	// The shared outer var must be from predicate constraints in the rule
 	// TODO: What if the var is from negative predicate?

--- a/ddlog_examples/formula2ddlog/formula2ddlog.dl
+++ b/ddlog_examples/formula2ddlog/formula2ddlog.dl
@@ -377,40 +377,72 @@ DDRhsInRule[(dd_head_union_atom_rhs_with_def, rule)] :-
 // s1 and s2 represent the shared variable between inner and outer scope
 
 // 1. Create `PreAggrContainer ::= (vco1: T1, vco2: T2,..., vcon: Tn, inner: SCHeadUnion)` where `vcox` is the 
-// variable in the outer scope and `Tn` is the type of that variable. 
+// variable in the outer scope and `Tn` is the type of that variable. `SCHeadUnion` should be available by
+// looking up the name.
+DDTypeSpec[setcompre_result_type], 
 DDTypeSpec[pre_aggr_container_ddtype], 
-DDRelation[pre_aggr_container_ddrelation] 
-// DDTypeSpec[], 
-// DDRelation[] 
-:-
+DDRelation[pre_aggr_container_ddrelation], 
+DDTypeSpec[post_aggr_container_ddtype], 
+DDRelation[post_aggr_container_ddrelation] :-
 	DependentSetcompre[(setcompre, rule)], 
 	// The shared outer var must be from predicate constraints in the rule
 	// TODO: What if the var is from negative predicate?
-	ConstraintInRule[(_, PredCons {false, pos_pred_term, _}, rule)],
-	OuterVarInDepSetcompre[(shared_outer_var, setcompre, rule)],
-	SubtermTypeSpec[(shared_outer_var, pos_pred_term, outer_var_typespec)],
+	// `src is Node()` is not included in relation SubtermTypeSpec.
+	ConstraintInRule[(_, PredCons {false, pos_pred_term, _}, setcompre.rule)],
+	OuterVarInDepSetcompre[(outer_var, setcompre, rule)],
+	// We derive the type of every subterm in each term.
+	SubtermTypeSpec[(outer_var, pos_pred_term, outer_var_typespec)],
 	var rule_id = rule.id,
 	var sc_id = setcompre.rule.id,
 	var head_union_type_name = "SCHeadUnion" ++ "R" ++ rule_id ++ "SC" ++ sc_id,
 	var pre_aggr_container_name = "PreAggrContainer" ++ "R" ++ rule_id ++ "SC" ++ sc_id, 
+	var post_aggr_container_name = "PostAggrContainer" ++ "R" ++ rule_id ++ "SC" ++ sc_id, 
+	var sc_result_name = "SCResult" ++ "R" ++ rule_id ++ "SC" ++ sc_id, 
 	// Find the pre-computed union type of all types that occur in the head of set comprehension
 	dd_head_union_typespec in DDTypeSpec[DDUnionTypeSpec {head_union_type_name, _}],
-	var group = (shared_outer_var, outer_var_typespec).
-		group_by((setcompre, rule, dd_head_union_typespec, pre_aggr_container_name)),
+	// Aggregate all shared variables for the new constructor `PreAggrContainer` 
+	// FIXME: The variables are aggregated in which order?
+	var group = (outer_var, outer_var_typespec).group_by((
+		setcompre, 
+		rule, 
+		dd_head_union_typespec, 
+		pre_aggr_container_name,
+		post_aggr_container_name,
+		sc_result_name)),
 	// Get the keys in `group_by()` because we need the name that is consumed in aggregation
-	(_, _, _, var pre_aggr_container_name2) = group.group_key(),
-	var fields_without_union = group.map(|var_and_typespec| 
+	(_,_,_, var pre_aggr_container_name2, var post_aggr_container_name2, var sc_result_name2) = group.group_key(),
+	var outer_var_fields = group.map(|var_and_typespec| 
 		DDField { to_string(var_and_typespec.0), ref_new(to_dd_typespec(var_and_typespec.1)) }
 	),
+	// `SCResult` the type of aggregation result
+	var setcompre_result_type = union_of_ddtypes(sc_result_name2, [Int, Float]),
 	// `PreAggrContainer ::= (vco1: T1, vco2: T2,..., vcon: Tn, inner: SCHeadUnion)`
-	var fields = vec_push_imm(fields_without_union, DDField { "sc_union", ref_new(dd_head_union_typespec) }), 
-	var field_list = from_vec(fields),
-	var pre_aggr_container_cons = DDTypeCons { pre_aggr_container_name2, field_list }, 
+	var pre_fields = vec_push_imm(outer_var_fields, DDField { "sc_union", ref_new(dd_head_union_typespec) }), 
+	var pre_field_list = from_vec(pre_fields),
+	var pre_aggr_container_cons = DDTypeCons { pre_aggr_container_name2, pre_field_list }, 
 	var pre_aggr_container_ddtype = DDUnionTypeSpec { 
 		pre_aggr_container_name2, 
 		from_singleton_to_nonnull_list(pre_aggr_container_cons) 
 	},
-	var pre_aggr_container_ddrelation = DDRelation { false, pre_aggr_container_name2, pre_aggr_container_ddtype }.
+	var pre_aggr_container_ddrelation = DDRelation { 
+		false, 
+		pre_aggr_container_name2, 
+		pre_aggr_container_ddtype 
+	},
+	// TODO: result could be other numeric type and find a way to decide which type or types to use.
+	// `PostAggrContainer ::= (vco1: T1, vco2: T2,..., vcon: Tn, result: Integer+Float)`
+	var post_fields = vec_push_imm(outer_var_fields, DDField{ "sc_result", ref_new(setcompre_result_type) }),
+	var post_field_list = from_vec(post_fields),
+	var post_aggr_container_cons = DDTypeCons { post_aggr_container_name2, post_field_list },
+	var post_aggr_container_ddtype = DDUnionTypeSpec { 
+		post_aggr_container_name2, 
+		from_singleton_to_nonnull_list(post_aggr_container_cons) 
+	},
+	var post_aggr_container_ddrelation = DDRelation { 
+		false, 
+		post_aggr_container_name2, 
+		post_aggr_container_ddtype 
+	}.
 
 
 // PreAggrContainer(vco,.., U::CONST1()),..., PreAggrContainer(vco,.., U::CONSTn()) :- 
@@ -461,37 +493,88 @@ DDAtomInRule[(dd_atom_for_sc_rule, sc_rule)] :-
 	// SCHeadUnion[tn] where `tn` is the term from the head of set comprehension
 	var dd_atom_for_sc_rule = DDAtom { None, ref_new(dd_pre_aggr_container_relation), dd_sc_head_term_expr }.
 
+
 // Aggregate the result grouped by shared variables
-// PostAggrContainer(vco1, vco2,..., vcon, val) :- PreAggrContainer(vco1, vco2,..., vcon, u), 
-// 	   u.group_by((vco1, vco2,..., vcon)), var val = g.some_aggr_func().
-DDRule[DDRule{ [post_aggr_atom], [pre_aggr_container_atom_rhs]}] :-
+// PostAggrContainer(vco1, vco2,..., vcon, val) :- 
+// 		PreAggrContainer(vco1, vco2,..., vcon, u), 
+// 	    u.group_by((vco1, vco2,..., vcon)), 
+// 		var result = g.some_aggr_func().
+DDRule[DDRule{ 
+	[post_aggr_atom], 
+	[pre_aggr_container_atom_rhs, group_assignment, result_assignment] 
+}] :-
 	DependentSetcompre[(setcompre, rule)], 
 	OuterVarInDepSetcompre[(outer_var, setcompre, rule)],
 	var group = (outer_var).group_by((setcompre, rule)),
 	(var setcompre2, var rule2) = group.group_key(),
 	var rule_id = rule2.id,
 	var sc_id = setcompre2.rule.id,
-	var dd_outer_variable_exprs = group.map(|outer_var| DDTermExpr{ref_new(to_dd_term(outer_var))}),
+	var dd_outer_variable_exprs = group.map(|outer_var| DDTermExpr { ref_new(to_dd_term(outer_var)) } ),
+	var dd_outer_variable_expr_refs = group.map(|outer_var| 
+		ref_new(DDTermExpr { ref_new(to_dd_term(outer_var)) }) 
+	),
 	var pre_aggr_container_name = "PreAggrContainer" ++ "R" ++ rule_id ++ "SC" ++ sc_id, 
 	var post_aggr_container_name = "PostAggrContainer" ++ "R" ++ rule_id ++ "SC" ++ sc_id, 
+	// Create an RHS expression for `PreAggrContainer(vco1, vco2,..., vcon, u)`
 	var u_term = DDVar {"u"},
-	var pre_aggr_container_term = DDCons {
-		pre_aggr_container_name,
-		from_vec(vec_push_imm(dd_outer_variable_exprs, DDTermExpr{ref_new(u_term)}))
-	},
+	var pre_aggr_fields = vec_push_imm(dd_outer_variable_exprs, DDTermExpr{ref_new(u_term)}),
+	var pre_aggr_container_term = DDCons { pre_aggr_container_name, from_vec(pre_aggr_fields) },
 	var pre_aggr_container_term_expr = DDTermExpr { ref_new(pre_aggr_container_term) },
 	dd_pre_aggr_container_relation in DDRelation[DDRelation {_,pre_aggr_container_name,_}],
-	var pre_aggr_container_atom = DDAtom {None, ref_new(dd_pre_aggr_container_relation), pre_aggr_container_term_expr},
+	var pre_aggr_container_atom = DDAtom {
+		None, 
+		ref_new(dd_pre_aggr_container_relation), 
+		pre_aggr_container_term_expr
+	},
 	var pre_aggr_container_atom_rhs = DDRhsAtom {false, pre_aggr_container_atom}, 
+	var val_term = DDVar {"result"},
 	dd_post_aggr_container_relation in DDRelation[DDRelation {_,post_aggr_container_name,_}],
 	var post_aggr_term = DDCons {
 		post_aggr_container_name,
-		from_vec(vec_push_imm(dd_outer_variable_exprs, DDTermExpr{ref_new(DDVar{"val"})}))
+		from_vec(vec_push_imm(dd_outer_variable_exprs, DDTermExpr{ref_new(val_term)}))
 	},
-	var post_aggr_term_expr = DDTermExpr{ ref_new(post_aggr_term) }, 
-	var post_aggr_atom = DDAtom {None, ref_new(dd_post_aggr_container_relation), post_aggr_term_expr}.
+	var post_aggr_term_expr = DDTermExpr { ref_new(post_aggr_term) }, 
+	var post_aggr_atom = DDAtom {None, ref_new(dd_post_aggr_container_relation), post_aggr_term_expr},
+	// var g = u.group_by((vco1, vco2,..., vcon)).
+	var u_expr_ref = ref_new(DDTermExpr { ref_new(u_term) }),
+	var u_vec = [u_expr_ref],
+	var group_assignment = DDGroup { 
+		"g", DDTupleExpr{u_vec}, 
+		DDTupleExpr{ dd_outer_variable_expr_refs } 
+	},
+	// var result = g.group_count().
+	var result_ref = ref_new(DDVarDecl { "result" }),
+	var result_expr = DDTermExpr { result_ref },
+	var g_ref = ref_new(DDVar { "g" }),
+	var g_expr_ref = ref_new(DDTermExpr { g_ref }),
+	// TODO: Replace `group_count` based on the exact setcompre.sop
+	var aggregation_expr = DDDotFunctionCallExpr { g_expr_ref, "group_count", vec_empty() },
+	var result_assignment = DDRhsAssignment { result_expr, aggregation_expr }.
 
 
+// Find the variable that represents the aggregation result and use it in the `PostAggrContainer` to
+// create a new RHS and add it to the original rule that contains the aggregation.
+DDRhsInRule[(ddrhs, rule)] :-
+	DependentSetcompre[(setcompre, rule)], 
+	ConstraintInRule[(_, AssignCons{def_term, SetcompreExpr{setcompre_ref}}, rule)], 
+	ref_new(setcompre) == setcompre_ref,
+	OuterVarInDepSetcompre[(outer_var, setcompre, rule)],
+	var group = (outer_var).group_by((setcompre, rule, def_term)),
+	(var setcompre2, var rule2, var def_term2) = group.group_key(),
+	var rule_id = rule2.id,
+	var sc_id = setcompre2.rule.id,
+	var dd_outer_variable_exprs = group.map(|outer_var| DDTermExpr { ref_new(to_dd_term(outer_var)) } ),
+	var post_aggr_container_name = "PostAggrContainer" ++ "R" ++ rule_id ++ "SC" ++ sc_id, 
+	// var val_term = DDVar {"result"},
+	var dd_def_term = to_dd_term(def_term2),
+	dd_post_aggr_container_relation in DDRelation[DDRelation {_,post_aggr_container_name,_}],
+	var post_aggr_term = DDCons {
+		post_aggr_container_name,
+		from_vec(vec_push_imm(dd_outer_variable_exprs, DDTermExpr{ref_new(dd_def_term)}))
+	},
+	var post_aggr_term_expr = DDTermExpr { ref_new(post_aggr_term) }, 
+	var post_aggr_atom = DDAtom {None, ref_new(dd_post_aggr_container_relation), post_aggr_term_expr},
+	var ddrhs = DDRhsAtom { false, post_aggr_atom }.
 
 /***************** Create New DDRule in DDlog ********************/
 AtomVecOfRule[(atom_vec, rule_ref)] :- Rule[rule], var rule_ref = ref_new(rule), DDAtomInRule[(ddatom, rule_ref)], 

--- a/ddlog_examples/formula2ddlog/formula2ddlog_lib/src/main.rs
+++ b/ddlog_examples/formula2ddlog/formula2ddlog_lib/src/main.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::convert::TryInto;
 
+use differential_datalog::program::Relation;
 use differential_datalog::record::IntoRecord;
 // Trait that must be implemented by an instance of a DDlog program. 
 // Type that represents a set of changes to DDlog relations.
@@ -388,11 +389,11 @@ fn main() {
     // DDLogTransformation::dump_delta_by_relid(&delta, Relations::langs_formula_SubtermTypeSpec as RelId);
     // DDLogTransformation::dump_delta_by_relid(&delta, Relations::DDTermInSetcompreHead as RelId);
     // DDLogTransformation::dump_delta_by_relid(&delta, Relations::langs_formula_ConstraintInRule as RelId);
-    // DDLogTransformation::dump_delta_by_relid(&delta, Relations::langs_formula_ConstraintInRule as RelId);
     // DDLogTransformation::dump_delta_by_relid(&delta, Relations::langs_formula_DependentSetcompre as RelId);
     // DDLogTransformation::dump_delta_by_relid(&delta, Relations::DDAtomInRule as RelId);
     // DDLogTransformation::dump_delta_by_relid(&delta, Relations::DDRhsInRule as RelId);
     // DDLogTransformation::dump_delta_by_relid(&delta, Relations::langs_formula_OuterVarInDepSetcompre as RelId);
     // DDLogTransformation::dump_delta_by_relid(&delta, Relations::AtomVecOfRule as RelId);
+    // DDLogTransformation::dump_delta_by_relid(&delta, Relations::langs_formula_Rule as RelId);
     DDLogTransformation::print_program(&delta);
 }

--- a/ddlog_examples/formula2ddlog/formula2ddlog_lib/src/main.rs
+++ b/ddlog_examples/formula2ddlog/formula2ddlog_lib/src/main.rs
@@ -130,7 +130,7 @@ fn convert_setcompre(rid: String, sc: SetComprehension) -> Setcompre {
         val: atom
     });
     let default = convert_term(default_term);
-    Setcompre { rule: ref_new(&convert_rule(rid, sc_rule)), sop, default}
+    Setcompre { rule: ref_new(convert_rule(rid, sc_rule)), sop, default}
 }
 
 // Deal with setcompre expression separately because it needs to be assigned a rule id
@@ -138,7 +138,7 @@ fn convert_setcompre(rid: String, sc: SetComprehension) -> Setcompre {
 fn convert_setcompre_expr(sc_rule_id: String, expr: FExpr) -> Option<Expr> {
     if let FExpr::BaseExpr(base_expr) = expr {
         if let FBaseExpr::SetComprehension(setcompre) = base_expr {
-            let e = Expr::SetcompreExpr { sc: ref_new(&convert_setcompre(sc_rule_id, setcompre)) };
+            let e = Expr::SetcompreExpr { sc: ref_new(convert_setcompre(sc_rule_id, setcompre)) };
             return Some(e);
         }
     }
@@ -166,8 +166,8 @@ fn convert_expr(expr: FExpr) -> Option<Expr> {
             let left_expr = convert_expr(arith_expr.left.as_ref().clone()).unwrap();
             let right_expr = convert_expr(arith_expr.right.as_ref().clone()).unwrap();
             let e = Expr::ArithExpr { 
-                left: ref_new(&left_expr), 
-                right: ref_new(&right_expr), 
+                left: ref_new(left_expr), 
+                right: ref_new(right_expr), 
                 aop 
             };
             Some(e)


### PR DESCRIPTION
1. Support dependent set comprehension. For example, `hello :- src is Node(_), count({ dst | Edge(src, dst) }) = 0.`
2. Remove relative path in Cargo.toml
3. Update README with more clear instructions